### PR TITLE
🚑 fix(typo on docs section in Landing Page)

### DIFF
--- a/src/components/Docs.tsx
+++ b/src/components/Docs.tsx
@@ -21,8 +21,8 @@ const Docs: React.FC = () => {
             </div>
             <ul className="w-full list-disc text-left text-sm font-light text-text_color-100 md:text-base lg:text-lg">
               <li className="w-full font-body leading-6 md:leading-7 text-pretty">
-                สำเนาบัตรประจำตัวประชาชน หรือหนังสือเดินทาง (กรณีชาวต่างชาติ) ของอาจารย์่ที่ปรึกษา เฉพาะด้านหน้า
-                พร้อมเซ็นสำเนาถูกต้อง
+                สำเนาบัตรประจำตัวประชาชน หรือหนังสือเดินทาง (กรณีชาวต่างชาติ) ของอาจารย์่ที่ปรึกษาพร้อมเซ็นสำเนาถูกต้อง
+                เฉพาะด้านหน้า
               </li>
               <li className="w-full font-body leading-6 md:leading-7 text-pretty">
                 เอกสาร หรือหนังสือยืนยันสถานภาพการเป็นอาจารย์ประจำสถานศึกษา (บัตรประจำตัวครูอาจารย์,
@@ -46,8 +46,8 @@ const Docs: React.FC = () => {
             <ul className=" w-full list-disc text-left text-sm text-pretty font-ibm font-light leading-6 md:leading-7 text-text_color-100 md:text-base lg:text-lg">
               <li className="m-auto w-full ">รูปถ่ายนักเรียนผู้เข้าแข่งขัน</li>
               <li className="m-auto w-full ">
-                สำเนาบัตรประจำตัวประชาชน หรือหนังสือเดินทาง (กรณีชาวต่างชาติ) ของผู้เข้าแข่งขัน เฉพาะด้านหน้า
-                พร้อมเซ็นสำเนาถูกต้อง
+                สำเนาบัตรประจำตัวประชาชน หรือหนังสือเดินทาง (กรณีชาวต่างชาติ) ของผู้เข้าแข่งขันพร้อมเซ็นสำเนาถูกต้อง
+                เฉพาะด้านหน้า
               </li>
               <li className="m-auto w-full ">ปพ.7 ของผู้เข้าแข่งขันฉบับจริง</li>
             </ul>


### PR DESCRIPTION
fix the typo based on Moji's request

Before:  

![image](https://github.com/user-attachments/assets/8b76db47-f19d-47d5-9104-c17314dff200)

After:  

![image](https://github.com/user-attachments/assets/8bdf8180-15eb-44c9-ab6f-80ed79b8f035)
